### PR TITLE
Add policy for www.haskell.org repo access

### DIFF
--- a/proposals/0004-haskell-org-repo-maintainers.md
+++ b/proposals/0004-haskell-org-repo-maintainers.md
@@ -1,0 +1,38 @@
+---
+author: Tom Ellis
+date-accepted: 2022-03-30
+discussion: https://github.com/haskell-org/committee/pull/11
+---
+
+# Write access to haskell.org website repo
+
+The Haskell.org committee welcomes PRs from community contributors to
+the haskell.org website.  However, for security purposes it is
+important to restrict direct write access to the repository which the
+website is built from.
+
+This policy determines who should have write access to any settings
+and source repositories associated with the www.haskell.org website.
+The settings and source repositories are currently hosted on the
+GitHub platform, at
+<https://github.com/haskell-infra/www.haskell.org/>.
+
+* All members of the Haskell.org committee should have write access,
+  to be used for carrying out their normal duties around the website.
+
+* All members of the Haskell.org committee will, on request, be
+  granted the highest level of admin access.  For redundancy purposes,
+  at all times there should be at least three committee members with
+  the highest level of admin access.
+
+* All members of the Haskell.org infrastructure admins team will, on
+  request, be granted write access, for carrying out their normal
+  duties around maintenance of Haskell.org infrastructure.
+
+* By vote of the Haskell.org committee others may be granted write
+  access to the settings and source repositories, for a limited time
+  and for a limited purpose, if the Haskell.org committee deems such
+  access necessary.
+
+* No one else may have write access to the settings and source
+  repositories under any other circumstances.


### PR DESCRIPTION
Draft policy tackling: https://github.com/haskell-org/committee/issues/9

Committee: Hopefully we can vote on this in committee meeting on Fri 18th Feb 2022.
